### PR TITLE
Adds TIME data type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,28 @@ is invoked.
 Incremental replication works in conjunction with a state file to only extract
 new records each time the tap is invoked. This requires a replication key to be
 specified in the table's metadata as well.
+
+### To run tests:
+
+1. Define environment variables that requires running the tests
+```
+  export TAP_SNOWFLAKE_ACCOUNT=<snowflake-account-name>
+  export TAP_SNOWFLAKE_DBNAME=<snowflake-database-name>
+  export TAP_SNOWFLAKE_USER=<snowflake-user>
+  export TAP_SNOWFLAKE_PASSWORD=<snowfale-password>
+  export TAP_SNOWFLAKE_WAREHOUSE=<snowflake-warehouse>
+```
+
+2. Install python dependencies in a virtual env and run nose unit and integration tests
+```
+  python3 -m venv venv
+  . venv/bin/activate
+  pip install --upgrade pip
+  pip install .
+  pip install nose
+```
+
+3. To run unit tests:
+```
+  nosetests
+```

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
       long_description = f.read()
 
 setup(name='pipelinewise-tap-snowflake',
-      version='1.0.2',
+      version='1.0.3',
       description='Singer.io tap for extracting data from Snowflake - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -50,7 +50,7 @@ STRING_TYPES = set(['varchar', 'char', 'character', 'string', 'text'])
 NUMBER_TYPES = set(['number', 'decimal', 'numeric'])
 INTEGER_TYPES = set(['int', 'integer', 'bigint', 'smallint'])
 FLOAT_TYPES = set(['float', 'float4', 'float8', 'real', 'double', 'double precision'])
-DATETIME_TYPES = set(['datetime', 'timestamp', 'date', 'time', 'timestamp_ltz', 'timestamp_ntz', 'timestamp_tz'])
+DATETIME_TYPES = set(['datetime', 'timestamp', 'date', 'timestamp_ltz', 'timestamp_ntz', 'timestamp_tz'])
 BINARY_TYPE = set(['binary', 'varbinary'])
 
 
@@ -80,6 +80,10 @@ def schema_for_column(c):
     elif data_type in DATETIME_TYPES:
         result.type = ['null', 'string']
         result.format = 'date-time'
+
+    elif data_type == 'time':
+        result.type = ['null', 'string']
+        result.format = 'time'
 
     elif data_type in BINARY_TYPE:
         result.type = ['null', 'string']

--- a/tap_snowflake/sync_strategies/common.py
+++ b/tap_snowflake/sync_strategies/common.py
@@ -113,6 +113,9 @@ def row_to_singer_record(catalog_entry, version, row, columns, time_extracted):
             timedelta_from_epoch = epoch + elem
             row_to_persist += (timedelta_from_epoch.isoformat() + '+00:00',)
 
+        elif isinstance(elem, datetime.time):
+            row_to_persist += (str(elem),)
+
         elif isinstance(elem, bytes):
             # for BIT value, treat 0 as False and anything else as True
             if 'boolean' in property_type:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,6 @@ import singer
 import snowflake.connector
 
 import tap_snowflake
-import tap_snowflake.sync_strategies.common as common
 from tap_snowflake.connection import SnowflakeConnection
 
 SCHEMA_NAME='tap_snowflake_test'
@@ -42,9 +41,9 @@ def get_test_connection():
     return snowflake_conn
 
 
-def discover_catalog(connection):
+def discover_catalog(snowflake_conn):
     tap_config = get_tap_config()
-    catalog = tap_snowflake.discover_catalog(connection, tap_config)
+    catalog = tap_snowflake.discover_catalog(snowflake_conn, tap_config)
     streams = []
 
     for stream in catalog.streams:


### PR DESCRIPTION
Selecting TIME data types from snowflake table failed with:
```
TypeError: datetime.time(4, 0) is not JSON serializable
```

This PR converts datetime.time object to string