### PR TITLE
Updated dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-singer-python==5.3.1
-snowflake-connector-python==1.7.4
-backoff==1.3.2
+singer-python==5.9.0
+snowflake-connector-python==2.0.4
+backoff==1.8.0
 pendulum==1.2.0
+pytz==2018.4
+python-dateutil<2.8.1,>=2.1

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
       long_description = f.read()
 
 setup(name='pipelinewise-tap-snowflake',
-      version='1.0.4',
+      version='1.0.5',
       description='Singer.io tap for extracting data from Snowflake - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',
@@ -18,10 +18,12 @@ setup(name='pipelinewise-tap-snowflake',
       ],
       py_modules=['tap_snowflake'],
       install_requires=[
-          'singer-python==5.3.1',
-          'snowflake-connector-python==1.7.4',
-          'backoff==1.3.2',
-          'pendulum==1.2.0'
+            'singer-python==5.9.0',
+            'snowflake-connector-python==2.0.4',
+            'backoff==1.8.0',
+            'pendulum==1.2.0',
+            'pytz==2018.4',
+            'python-dateutil<2.8.1,>=2.1',
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
A snowflake tap is failing due to a module not found:
```
File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/bin/tap-snowflake", line 11, in <module>
    load_entry_point('pipelinewise-tap-snowflake==1.0.4', 'console_scripts', 'tap-snowflake')()
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/pkg_resources/__init__.py", line 480, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2693, in load_entry_point
    return ep.load()
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2324, in load
    return self.resolve()
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2330, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/tap_snowflake/__init__.py", line 22, in <module>
    import tap_snowflake.sync_strategies.full_table as full_table
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/tap_snowflake/sync_strategies/full_table.py", line 9, in <module>
    from tap_snowflake.connection import SnowflakeConnection
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/tap_snowflake/connection.py", line 5, in <module>
    import snowflake.connector
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/snowflake/connector/__init__.py", line 21, in <module>
    from .connection import SnowflakeConnection
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/snowflake/connector/connection.py", line 18, in <module>
    from .auth import Auth
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/snowflake/connector/auth.py", line 35, in <module>
    from .network import (CONTENT_TYPE_APPLICATION_JSON,
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/snowflake/connector/network.py", line 57, in <module>
    from .tool.probe_connection import probe_connection
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/snowflake/connector/tool/probe_connection.py", line 7, in <module>
    from asn1crypto import ocsp
ModuleNotFoundError: No module named 'asn1crypto'
```

This might be due to the usage of a old version of Snowflake connector.