### PR TITLE
Switch to pipelinewise-singer-python and name loggers

### DIFF
--- a/sample_logging.conf
+++ b/sample_logging.conf
@@ -1,0 +1,25 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=stderr
+
+[formatters]
+keys=child
+
+[logger_root]
+level=INFO
+handlers=stderr
+formatter=child
+propagate=0
+
+[handler_stderr]
+level=INFO
+class=StreamHandler
+formatter=child
+args=(sys.stderr,)
+
+[formatter_child]
+class=logging.Formatter
+format=time=%(asctime)s name=%(name)s level=%(levelname)s message=%(message)s
+datefmt=%Y-%m-%d %H:%M:%S

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='pipelinewise-tap-snowflake',
       ],
       py_modules=['tap_snowflake'],
       install_requires=[
-            'singer-python==5.9.0',
+            'pipelinewise-singer-python==1.*',
             'snowflake-connector-python==2.0.4',
             'backoff==1.8.0',
             'pendulum==1.2.0',

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -1,31 +1,28 @@
 #!/usr/bin/env python3
 # pylint: disable=missing-docstring,not-an-iterable,too-many-locals,too-many-arguments,too-many-branches,invalid-name,duplicate-code,too-many-statements
 
-import datetime
 import collections
-import itertools
-from itertools import dropwhile
 import copy
-
+import itertools
+import logging
 
 import singer
 import singer.metrics as metrics
 import singer.schema
-
-from singer import bookmarks
 from singer import metadata
 from singer import utils
-from singer.schema import Schema
 from singer.catalog import Catalog, CatalogEntry
+from singer.schema import Schema
 
 import tap_snowflake.sync_strategies.common as common
 import tap_snowflake.sync_strategies.full_table as full_table
 import tap_snowflake.sync_strategies.incremental as incremental
-
 from tap_snowflake.connection import SnowflakeConnection
 
+LOGGER = singer.get_logger('tap_snowflake')
 
-LOGGER = singer.get_logger()
+# Tone down snowflake connector logs noise
+logging.getLogger('snowflake.connector').setLevel(logging.WARNING)
 
 Column = collections.namedtuple('Column', [
     "table_catalog",

--- a/tap_snowflake/connection.py
+++ b/tap_snowflake/connection.py
@@ -4,7 +4,7 @@ import backoff
 import singer
 import snowflake.connector
 
-LOGGER = singer.get_logger()
+LOGGER = singer.get_logger('tap_snowflake')
 
 
 def retry_pattern():

--- a/tap_snowflake/sync_strategies/common.py
+++ b/tap_snowflake/sync_strategies/common.py
@@ -10,7 +10,7 @@ import singer.metrics as metrics
 from singer import metadata
 from singer import utils
 
-LOGGER = singer.get_logger()
+LOGGER = singer.get_logger('tap_snowflake')
 
 def escape(string):
     if '"' in string:

--- a/tap_snowflake/sync_strategies/full_table.py
+++ b/tap_snowflake/sync_strategies/full_table.py
@@ -8,7 +8,7 @@ from singer import metadata
 import tap_snowflake.sync_strategies.common as common
 from tap_snowflake.connection import SnowflakeConnection
 
-LOGGER = singer.get_logger()
+LOGGER = singer.get_logger('tap_snowflake')
 
 BOOKMARK_KEYS = {'last_pk_fetched', 'max_pk_values', 'version', 'initial_full_table_complete'}
 

--- a/tap_snowflake/sync_strategies/incremental.py
+++ b/tap_snowflake/sync_strategies/incremental.py
@@ -8,7 +8,7 @@ from singer import metadata
 from tap_snowflake.connection import SnowflakeConnection
 import tap_snowflake.sync_strategies.common as common
 
-LOGGER = singer.get_logger()
+LOGGER = singer.get_logger('tap_snowflake')
 
 BOOKMARK_KEYS = {'replication_key', 'replication_key_value', 'version'}
 

--- a/tests/test_tap_snowflake.py
+++ b/tests/test_tap_snowflake.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     import utils as test_utils
 
-LOGGER = singer.get_logger()
+LOGGER = singer.get_logger('tap_snowflake_tests')
 
 SCHEMA_NAME='tap_snowflake_test'
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,6 @@
 import os
+
 import singer
-import snowflake.connector
 
 import tap_snowflake
 from tap_snowflake.connection import SnowflakeConnection


### PR DESCRIPTION
Example of logs using the `sample_logging.conf` as the logging configuration

```
time=2020-02-10 10:36:32 name=tap_snowflake level=INFO message=SNOWFLAKE - Running query: 
        SELECT t.table_catalog,
               t.table_schema,
               t.table_name,
               t.table_type,
               t.row_count,
               c.column_name,
               c.data_type,
               c.character_maximum_length,
               c.numeric_precision,
               c.numeric_scale
            FROM information_schema.tables t,
                 information_schema.columns c
            WHERE t.table_catalog = c.table_catalog
              AND t.table_schema = c.table_schema
              AND t.table_name = c.table_name
              AND 1 = 1
              AND LOWER(t.table_schema) NOT IN ('information_schema')
        
time=2020-02-10 10:37:43 name=tap_snowflake level=INFO message=Beginning to sync ANALYTICS_DB_TEST.AUTOMATED_TESTS.CITY
time=2020-02-10 10:37:43 name=tap_snowflake level=INFO message=Stream ANALYTICS_DB_TEST-AUTOMATED_TESTS-CITY is using full table replication
time=2020-02-10 10:37:44 name=tap_snowflake level=INFO message=Running SELECT "DISTRICT","POPULATION","_SDC_BATCHED_AT","COUNTRYCODE","_SDC_EXTRACTED_AT","NAME","_SDC_DELETED_AT","ID" FROM "ANALYTICS_DB_TEST"."AUTOMATED_TESTS"."CITY"
time=2020-02-10 10:37:44 name=singer level=INFO message=METRIC: {"type": "counter", "metric": "record_count", "value": 1, "tags": {"database": "ANALYTICS_DB_TEST", "table": "CITY"}}
time=2020-02-10 10:37:44 name=singer level=INFO message=METRIC: {"type": "timer", "metric": "job_duration", "value": 1.1977527141571045, "tags": {"job_type": "sync_table", "database": "ANALYTICS_DB_TEST", "table": "CITY", "status": "succeeded"}}
```