### PR TITLE
[AP-601] delete redundant library "pytz"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(name='pipelinewise-tap-snowflake',
             'snowflake-connector-python==2.2.2',
             'backoff==1.8.0',
             'pendulum==1.2.0',
-            'pytz==2018.4',
             'python-dateutil<2.8.1,>=2.1',
       ],
       extras_require={


### PR DESCRIPTION
To resolve dependency conflicts, I'm dropping `'pytz==2018.4'` from the setup file because `pipelinewise-singer-python` already comes with a more recent version `pytz 2019.3` 