### PR TITLE
[AP-635] Discover only the required tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,15 @@ or
      "user": "my_user",
      "password": "password",
      "warehouse": "my_virtual_warehouse",
-     "filter_dbs": "database_name",
-     "filter_schemas": "schema1,schema2"
+     "tables": "db.schema.table1,db.schema.table2"
    }
    ```
 
-`filter_dbs` and `filter_schemas` are optional.
+**Note**: `tables` is a mandatory parameter as well to avoid long running catalog discovery process.
+Please specify fully qualified table and view names and only that ones that you need to extract otherwise you can
+end up with very long running discovery mode of this tap. Discovery mode is analysing table structures but
+Snowflake doesn't like selecting lot of rows from `INFORMATION_SCHEMA` or running `SHOW` commands that returns lot of
+rows. Please be as specific as possible.
 
 2. Run it in discovery mode to generate a `properties.json`
 

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -47,7 +47,8 @@ REQUIRED_CONFIG_KEYS = [
     'dbname',
     'user',
     'password',
-    'warehouse'
+    'warehouse',
+    'tables'
 ]
 
 # Snowflake data types
@@ -118,138 +119,60 @@ def create_column_metadata(cols):
     return metadata.to_list(mdata)
 
 
-def get_databases(snowflake_conn):
-    """Get snowflake databases"""
-    databases = snowflake_conn.query('SHOW DATABASES', max_records=SHOW_COMMAND_MAX_ROWS)
+def get_table_columns(snowflake_conn, tables):
+    """Get column definitions of a list of tables
 
-    # Return only the name of databases as a list
-    return [db['name'] for db in databases]
-
-
-def get_schemas(snowflake_conn, database):
-    """Get schemas of a database"""
-    schemas = []
-    try:
-        schemas = snowflake_conn.query(f'SHOW SCHEMAS IN DATABASE {database}', max_records=SHOW_COMMAND_MAX_ROWS)
-
-        # Get only the name of schemas as a list
-        schemas = [schema['name'] for schema in schemas]
-
-    # Catch exception when schema not exists and SHOW SCHEMAS throws a ProgrammingError
-    # Regexp to extract snowflake error code and message from the exception message
-    # Do nothing if schema not exists
-    except snowflake.connector.errors.ProgrammingError as exc:
-        # pylint: disable=anomalous-backslash-in-string
-        if re.match('.*\(02000\):.*\n.*does not exist.*', str(sys.exc_info()[1])):
-            pass
-        else:
-            raise exc
-
-    return schemas
-
-
-def get_table_columns(snowflake_conn, database, table_schemas=None, table_name=None):
-    """Get column definitions for every table in specific schemas(s)
-
-       It's using SHOW commands instead of INFORMATION_SCHEMA views bucause information_schemas views are slow
+       It's using SHOW commands instead of INFORMATION_SCHEMA views because information_schemas views are slow
        and can cause unexpected exception of:
             Information schema query returned too much data. Please repeat query with more selective predicates.
     """
     table_columns = []
-    if table_schemas or table_name:
-        for schema in table_schemas:
-            queries = []
+    for table in tables:
+        queries = []
 
-            LOGGER.info('Getting schema information for %s.%s...', database, schema)
+        LOGGER.info('Getting column information for %s...', table)
 
-            # Get column data types by SHOW commands
-            show_tables = f'SHOW TABLES IN SCHEMA {database}.{schema}'
-            show_views = f'SHOW TABLES IN SCHEMA {database}.{schema}'
-            show_columns = f'SHOW COLUMNS IN SCHEMA {database}.{schema}'
+        # Get column data types by SHOW commands
+        show_columns = f"SHOW COLUMNS IN TABLE {table}"
 
-            # Convert output of SHOW commands to tables and use SQL joins to get every required information
-            select = f"""
-                WITH
-                  show_tables   AS (SELECT * FROM TABLE(RESULT_SCAN(LAST_QUERY_ID(-3)))),
-                  show_views    AS (SELECT * FROM TABLE(RESULT_SCAN(LAST_QUERY_ID(-2)))),
-                  show_columns  AS (SELECT * FROM TABLE(RESULT_SCAN(LAST_QUERY_ID(-1))))
-                SELECT show_columns."database_name"     AS table_catalog
-                      ,show_columns."schema_name"       AS table_schema
-                      ,show_columns."table_name"        AS table_name
-                      ,CASE
-                         WHEN show_tables."name" IS NOT NULL THEN 'BASE TABLE'
-                         ELSE 'VIEW'
-                       END table_type
-                      ,show_tables."rows"               AS row_count
-                      ,show_columns."column_name"       AS column_name
-                      -- ----------------------------------------------------------------------------------------
-                      -- Character and numeric columns display their generic data type rather than their defined
-                      -- data type (i.e. TEXT for all character types, FIXED for all fixed-point numeric types,
-                      -- and REAL for all floating-point numeric types).
-                      --
-                      -- Further info at https://docs.snowflake.net/manuals/sql-reference/sql/show-columns.html
-                      -- ----------------------------------------------------------------------------------------
-                      ,CASE PARSE_JSON(show_columns."data_type"):type::varchar
-                         WHEN 'FIXED' THEN 'NUMBER'
-                         WHEN 'REAL'  THEN 'FLOAT'
-                         ELSE PARSE_JSON("data_type"):type::varchar
-                       END data_type
-                      ,PARSE_JSON(show_columns."data_type"):length::number      AS character_maximum_length
-                      ,PARSE_JSON(show_columns."data_type"):precision::number   AS numeric_precision
-                      ,PARSE_JSON(show_columns."data_type"):scale::number       AS numeric_scale
-                  FROM show_columns
-                       LEFT JOIN show_tables
-                              ON show_tables."database_name" = show_columns."database_name"
-                             AND show_tables."schema_name"   = show_columns."schema_name"
-                             AND show_tables."name"          = show_columns."table_name"
-                       LEFT JOIN show_views
-                              ON show_views."database_name" = show_columns."database_name"
-                             AND show_views."schema_name"   = show_columns."schema_name"
-                             AND show_views."name"          = show_columns."table_name"
-            """
-            queries.extend([show_tables, show_views, show_columns, select])
+        # Convert output of SHOW commands to tables and use SQL joins to get every required information
+        select = f"""
+            WITH
+              show_columns  AS (SELECT * FROM TABLE(RESULT_SCAN(LAST_QUERY_ID(-1))))
+            SELECT show_columns."database_name"     AS table_catalog
+                  ,show_columns."schema_name"       AS table_schema
+                  ,show_columns."table_name"        AS table_name
+                  ,show_columns."column_name"       AS column_name
+                  -- ----------------------------------------------------------------------------------------
+                  -- Character and numeric columns display their generic data type rather than their defined
+                  -- data type (i.e. TEXT for all character types, FIXED for all fixed-point numeric types,
+                  -- and REAL for all floating-point numeric types).
+                  --
+                  -- Further info at https://docs.snowflake.net/manuals/sql-reference/sql/show-columns.html
+                  -- ----------------------------------------------------------------------------------------
+                  ,CASE PARSE_JSON(show_columns."data_type"):type::varchar
+                     WHEN 'FIXED' THEN 'NUMBER'
+                     WHEN 'REAL'  THEN 'FLOAT'
+                     ELSE PARSE_JSON("data_type"):type::varchar
+                   END data_type
+                  ,PARSE_JSON(show_columns."data_type"):length::number      AS character_maximum_length
+                  ,PARSE_JSON(show_columns."data_type"):precision::number   AS numeric_precision
+                  ,PARSE_JSON(show_columns."data_type"):scale::number       AS numeric_scale
+              FROM show_columns
+        """
+        queries.extend([show_columns, select])
 
-            # Run everything in one transaction
-            try:
-                columns = snowflake_conn.query(queries, max_records=SHOW_COMMAND_MAX_ROWS)
-                table_columns.extend(columns)
-
-            # Catch exception when schema not exists and SHOW COLUMNS throws a ProgrammingError
-            # Regexp to extract snowflake error code and message from the exception message
-            # Do nothing if schema not exists
-            except snowflake.connector.errors.ProgrammingError as exc:
-                # pylint: disable=anomalous-backslash-in-string
-                if re.match('.*\(02000\):.*\n.*does not exist.*', str(sys.exc_info()[1])):
-                    pass
-                else:
-                    raise exc
+        # Run everything in one transaction
+        columns = snowflake_conn.query(queries, max_records=SHOW_COMMAND_MAX_ROWS)
+        table_columns.extend(columns)
 
     return table_columns
 
 
 def discover_catalog(snowflake_conn, config):
     """Returns a Catalog describing the structure of the database."""
-    filter_dbs_config = config.get('filter_dbs')
-    filter_schemas_config = config.get('filter_schemas')
-    databases = []
-    schemas = []
-
-    # Get databases
-    sql_columns = []
-    if filter_dbs_config:
-        databases = filter_dbs_config.split(',')
-    else:
-        databases = get_databases(snowflake_conn)
-    for database in databases:
-
-        # Get schemas
-        if filter_schemas_config:
-            schemas = filter_schemas_config.split(',')
-        else:
-            schemas = get_schemas(snowflake_conn, database)
-
-        table_columns = get_table_columns(snowflake_conn, database, schemas)
-        sql_columns.extend(table_columns)
+    tables = config.get('tables').split(',')
+    sql_columns = get_table_columns(snowflake_conn, tables)
 
     table_info = {}
     columns = []

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -133,7 +133,7 @@ def get_table_columns(snowflake_conn, tables):
         LOGGER.info('Getting column information for %s...', table)
 
         # Get column data types by SHOW commands
-        show_columns = f"SHOW COLUMNS IN TABLE {table}"
+        show_columns = f'SHOW COLUMNS IN TABLE {table}'
 
         # Convert output of SHOW commands to tables and use SQL joins to get every required information
         select = f"""

--- a/tap_snowflake/connection.py
+++ b/tap_snowflake/connection.py
@@ -36,7 +36,8 @@ def validate_config(config):
         'dbname',
         'user',
         'password',
-        'warehouse'
+        'warehouse',
+        'tables'
     ]
 
     # Check if mandatory keys exist

--- a/tests/integration/test_tap_snowflake.py
+++ b/tests/integration/test_tap_snowflake.py
@@ -90,7 +90,7 @@ class TestTypeMapping(unittest.TestCase):
         # Discover catalog object including only TEST_TYPE_MAPPING table to run detailed tests later
         cls.dt_catalog = test_utils.discover_catalog(
             cls.snowflake_conn,
-            {'tables': f"{SCHEMA_NAME}.test_type_mapping"})
+            {'tables': f'{SCHEMA_NAME}.test_type_mapping'})
 
         cls.dt_stream = cls.dt_catalog.streams[0]
         cls.dt_schema = cls.dt_catalog.streams[0].schema

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -7,23 +7,16 @@ from tap_snowflake.connection import SnowflakeConnection
 
 SCHEMA_NAME='tap_snowflake_test'
 
+
 def get_db_config():
-    config = {}
-    config['account'] = os.environ.get('TAP_SNOWFLAKE_ACCOUNT')
-    config['dbname'] = os.environ.get('TAP_SNOWFLAKE_DBNAME')
-    config['user'] = os.environ.get('TAP_SNOWFLAKE_USER')
-    config['password'] = os.environ.get('TAP_SNOWFLAKE_PASSWORD')
-    config['warehouse'] = os.environ.get('TAP_SNOWFLAKE_WAREHOUSE')
-
-    return config
-
-
-def get_tap_config():
-    config = {}
-    config['filter_dbs'] = os.environ.get('TAP_SNOWFLAKE_DBNAME')
-    config['filter_schemas'] = SCHEMA_NAME
-
-    return config
+    return {
+        'account': os.environ.get('TAP_SNOWFLAKE_ACCOUNT'),
+        'dbname': os.environ.get('TAP_SNOWFLAKE_DBNAME'),
+        'user': os.environ.get('TAP_SNOWFLAKE_USER'),
+        'password': os.environ.get('TAP_SNOWFLAKE_PASSWORD'),
+        'warehouse': os.environ.get('TAP_SNOWFLAKE_WAREHOUSE'),
+        'tables': 'FAKE_TABLES'
+    }
 
 
 def get_test_connection():
@@ -41,9 +34,8 @@ def get_test_connection():
     return snowflake_conn
 
 
-def discover_catalog(snowflake_conn):
-    tap_config = get_tap_config()
-    catalog = tap_snowflake.discover_catalog(snowflake_conn, tap_config)
+def discover_catalog(snowflake_conn, config):
+    catalog = tap_snowflake.discover_catalog(snowflake_conn, config)
     streams = []
 
     for stream in catalog.streams:


### PR DESCRIPTION
This PR adds the mandatory `tables` parameter to `config.json` to avoid analysing entire databases and schemas with tens of thousands of tables and columns. Pipelinewise will generate this value automatically when parsing the tap YAML files.

There are two methods to analyse entire databases but both of them causing issues when a schema has hundreds of tables:
1) Selecting from `INFORMATION_SCHEMA`: This is very slow in Snowflake and doesn't allow selecting lot of records
2) Using `SHOW SCHEMA|TABLE|COLUMNS` commands: This is fast but one show command can return max 10000 records
