### PR TITLE
v2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
       long_description = f.read()
 
 setup(name='pipelinewise-tap-snowflake',
-      version='1.1.2',
+      version='2.0.0',
       description='Singer.io tap for extracting data from Snowflake - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
Bump major version, to 2.0.0.

Not backward compatible config changes:
 `tables` is new mandatory parameter and `filter_dbs` got deleted