### PR TITLE
[AP-666] Add optional pandas and pyarrow packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,12 @@ setup(name='pipelinewise-tap-snowflake',
       py_modules=['tap_snowflake'],
       install_requires=[
             'pipelinewise-singer-python==1.*',
-            'snowflake-connector-python==2.2.2',
+            'snowflake-connector-python==2.2.9',
+            'pyarrow==0.17.0',
+            'pandas==1.0.5',
             'backoff==1.8.0',
             'pendulum==1.2.0',
-            'python-dateutil<2.8.1,>=2.1',
+            'python-dateutil<2.8.1,>=2.1'
       ],
       extras_require={
           'test': [


### PR DESCRIPTION
Install optional `pandas` and `pyarrow` to avoid warnings in log: `Failed to import optional packages, No module named 'pandas'`