### PR TITLE
Replace usage of LAST_QUERY_ID with query id from cursor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,15 +11,9 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install --upgrade pip
+            pip install --upgrade pip setuptools wheel
             pip install .[test]
       
-      - run:
-          name: Check dependencies for conflict
-          command: |
-            . venv/bin/activate
-            pip check && echo "No conflicts" || exit 1
-            
       - run:
           name: 'Check code formatting and do pylinting'
           command: |

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -138,7 +138,7 @@ def get_table_columns(snowflake_conn, tables):
         # Convert output of SHOW commands to tables and use SQL joins to get every required information
         select = f"""
             WITH
-              show_columns  AS (SELECT * FROM TABLE(RESULT_SCAN(LAST_QUERY_ID(-1))))
+              show_columns  AS (SELECT * FROM TABLE(RESULT_SCAN(%(LAST_QID)s)))
             SELECT show_columns."database_name"     AS table_catalog
                   ,show_columns."schema_name"       AS table_schema
                   ,show_columns."table_name"        AS table_name


### PR DESCRIPTION
## Problem

There seems to be an intermittent issue when running a list of query using `connection.query` function the order in Snowflake history shows that `start transaction` is the second instead of first, this messes up with queries that rely on `LAST_QUERY_ID()` results. for example the `select .. from TABLE(RESULT_SCAN(LAST_QUERY_ID()))` fails with:

```
ime=2021-01-11 05:00:11 logger_name=tap_snowflake log_level=INFO message=Getting column information for AP_INFO_CLEAR.SNOWFLAKE_QUERY_HISTORY...
time=2021-01-11 05:00:11 logger_name=tap_snowflake log_level=CRITICAL message=000904 (42000): SQL compilation error: error line 3 at position 19
invalid identifier 'SHOW_COLUMNS."database_name"'
Traceback (most recent call last):
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/bin/tap-snowflake", line 8, in <module>
    sys.exit(main())
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/tap_snowflake/__init__.py", line 500, in main
    raise exc
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/tap_snowflake/__init__.py", line 497, in main
    main_impl()
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/tap_snowflake/__init__.py", line 490, in main_impl
    do_sync(snowflake_conn, args.config, catalog, state)
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/tap_snowflake/__init__.py", line 473, in do_sync
    catalog = get_streams(snowflake_conn, catalog, config, state)
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/tap_snowflake/__init__.py", line 348, in get_streams
    discovered = discover_catalog(snowflake_conn, config)
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/tap_snowflake/__init__.py", line 175, in discover_catalog
    sql_columns = get_table_columns(snowflake_conn, tables)
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/tap_snowflake/__init__.py", line 166, in get_table_columns
    columns = snowflake_conn.query(queries, max_records=SHOW_COMMAND_MAX_ROWS)
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/tap_snowflake/connection.py", line 103, in query
    cur.execute(sql, params)
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/snowflake/connector/cursor.py", line 605, in execute
    errvalue)
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/snowflake/connector/errors.py", line 125, in errorhandler_wrapper
    cursor.errorhandler(connection, cursor, error_class, error_value)
  File "/home/pipelinewise/pipelinewise/.virtualenvs/tap-snowflake/lib/python3.6/site-packages/snowflake/connector/errors.py", line 90, in default_errorhandler
    done_format_msg=error_value.get('done_format_msg'))
snowflake.connector.errors.ProgrammingError: 000904 (42000): SQL compilation error: error line 3 at position 19
invalid identifier 'SHOW_COLUMNS."database_name"'
```

## Proposed changes

Simlar issue was fixed in target snowflake here: https://github.com/transferwise/pipelinewise-target-snowflake/pull/130
So introducing the same changes:

* Force start transaction first but running it outside of the loop.
* To reduce the dynamic nature of select .. from TABLE(RESULT_SCAN(LAST_QUERY_ID()));, make use of the SF connector cursor ability to return the query id with the attribute `sfqid` and then pass it to the next query in the list as a named parameter.
* A reserved prepared statement param `LAST_QID` is introduced.

## Types of changes

What types of changes does your code introduce to tap-snowflake?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions