### PR TITLE
Bump snowflake-connector-python to 2.3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-singer-python==5.9.0
-snowflake-connector-python==2.0.4
-backoff==1.8.0
-pendulum==1.2.0
-pytz==2018.4
-python-dateutil<2.8.1,>=2.1

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='pipelinewise-tap-snowflake',
       py_modules=['tap_snowflake'],
       install_requires=[
             'pipelinewise-singer-python==1.*',
-            'snowflake-connector-python==2.3.6',
+            'snowflake-connector-python==2.3.7',
             'pyarrow==0.17.0',
             'pandas==1.0.5',
             'backoff==1.8.0',


### PR DESCRIPTION
## Problem

Snowflake connector is not up to date and not in sync with the snowflake-connector used in the target-snowflake.

## Proposed changes

Bump `snowflake-connector-python` to 2.3.7.
Also, this PR deletes `requirements.txt` because we rely only packages in `setup.py`.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions