### PR TITLE
Make tap_stream_id variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ or
      "user": "my_user",
      "password": "password",
      "warehouse": "my_virtual_warehouse",
-     "tables": "db.schema.table1,db.schema.table2"
+     "tables": "db.schema.table1,db.schema.table2",
+     "stream_id_template": "{catalog_name}-{schema_name}-{table_name}"
    }
    ```
 

--- a/tap_snowflake/__init__.py
+++ b/tap_snowflake/__init__.py
@@ -173,6 +173,7 @@ def discover_catalog(snowflake_conn, config):
     """Returns a Catalog describing the structure of the database."""
     tables = config.get('tables').split(',')
     sql_columns = get_table_columns(snowflake_conn, tables)
+    stream_id_template = config.get('stream_id_template', '{catalog_name}-{schema_name}-{table_name}')
 
     table_info = {}
     columns = []
@@ -231,7 +232,7 @@ def discover_catalog(snowflake_conn, config):
                 table=table_name,
                 stream=table_name,
                 metadata=metadata.to_list(md_map),
-                tap_stream_id=common.generate_tap_stream_id(table_catalog, table_schema, table_name),
+                tap_stream_id=common.generate_tap_stream_id(stream_id_template, table_catalog, table_schema, table_name),
                 schema=schema)
 
             entries.append(entry)

--- a/tap_snowflake/sync_strategies/common.py
+++ b/tap_snowflake/sync_strategies/common.py
@@ -20,9 +20,9 @@ def escape(string):
     return '"{}"'.format(string)
 
 
-def generate_tap_stream_id(catalog_name, schema_name, table_name):
+def generate_tap_stream_id(stream_id_template, catalog_name, schema_name, table_name):
     """Generate tap stream id as appears in properties.json"""
-    return catalog_name + '-' + schema_name + '-' + table_name
+    return stream_id_template.format(catalog_name=catalog_name, schema_name=schema_name, table_name=table_name)
 
 
 def get_stream_version(tap_stream_id, state):

--- a/tests/integration/test_tap_snowflake.py
+++ b/tests/integration/test_tap_snowflake.py
@@ -105,6 +105,17 @@ class TestTypeMapping(unittest.TestCase):
         # Create config to discover three tables
         catalog = test_utils.discover_catalog(
             self.snowflake_conn,
+            {'tables': f'{SCHEMA_NAME}.empty_table', 'stream_id_template': 'snowflake-{catalog_name}-{table_name}'})
+
+        # Three tables should be discovered
+        tap_stream_ids = [s.tap_stream_id for s in catalog.streams]
+        self.assertCountEqual(tap_stream_ids, ['SNOWFLAKE-TAP_SNOWFLAKE_TEST-EMPTY_TABLE'])
+
+    def test_discover_catalog_with_multiple_table(self):
+        """Validate if discovering catalog with filter_tables option working as expected"""
+        # Create config to discover three tables
+        catalog = test_utils.discover_catalog(
+            self.snowflake_conn,
             {'tables': f'{SCHEMA_NAME}.empty_table_1,{SCHEMA_NAME}.empty_table_2,{SCHEMA_NAME}.test_type_mapping'})
 
         # Three tables should be discovered


### PR DESCRIPTION
## Problem

We are using Meltano with `pipelinewise-tap-snowflake` and `pipelinewise-target-postgres`. It appears the target names the result tables after the stream ID.

In our case, we use the result Postgres tables on different environments with different source Snowflake databases. This makes our migrations quite complex.

## Proposed changes

This change keeps backwards compatibility to current behaviour, but also adds some more flexibility for naming resulting resources.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions