### PR TITLE
Fix invalid timestamp format

### DIFF
--- a/tap_snowflake/sync_strategies/common.py
+++ b/tap_snowflake/sync_strategies/common.py
@@ -123,7 +123,7 @@ def row_to_singer_record(catalog_entry, version, row, columns, time_extracted):
     for idx, elem in enumerate(row):
         property_type = catalog_entry.schema.properties[columns[idx]].type
         if isinstance(elem, datetime.datetime):
-            row_to_persist += (elem.isoformat() + '+00:00',)
+            row_to_persist += (elem.isoformat(),)
 
         elif isinstance(elem, datetime.date):
             row_to_persist += (elem.isoformat() + 'T00:00:00+00:00',)


### PR DESCRIPTION
## Problem
When i use this tap with postgres-target it seems to complain about the extra `+00:00` which is already present in iso format 

```
target-postgres | psycopg2.errors.InvalidDatetimeFormat: invalid input syntax for type timestamp: "2021-07-09T00:00:43.832000+00:00+00:00"
target-postgres | CONTEXT:  COPY tmp_b426002c_6ba5_402f_9327_770cae94e3c2, line 1, column recommendation_time: "2021-07-09T00:00:43.832000+00:00+00:00"
target-postgres |
meltano         | [Errno 32] Broken pipe
```
## Proposed changes

Remove appending of extraneous `+00:00` 

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ x] Description above provides context of the change
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] Unit tests for changes (not needed for documentation changes)
- [ x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions